### PR TITLE
Support pkexec command in addition to gksudo for i.e. Fedora

### DIFF
--- a/lib/config.coffee
+++ b/lib/config.coffee
@@ -13,7 +13,7 @@ else
       type: 'string'
       description: 'Graphical frondend for sudo'
       default: 'gksudo'
-      enum: [ 'gksudo', 'kdesu' ]
+      enum: [ 'gksudo', 'kdesu', 'pkexec' ]
 
     tryDefaultSave:
       order: 2

--- a/lib/susave.coffee
+++ b/lib/susave.coffee
@@ -59,8 +59,11 @@ module.exports = Susave =
           [ '-e', 'do shell script "' + cmd +
             '" with administrator privileges']
       else
+        sucmd = [ '--', 'sh', '-c', cmd ]
+        if atom.config.get('susave.sudoGui') == 'pkexec'
+          sucmd = [ 'sh', '-c', cmd ]
         res = spawnSync atom.config.get('susave.sudoGui'),
-          [ '--', 'sh', '-c', cmd ]
+          sucmd
       tempfile.removeCallback
 
       if res?.status != 0


### PR DESCRIPTION
Hi,

I waited for some time for atom for providing a similar plugin. So I was really happy to find your package.
Unfortunately it didn't work under Fedora, as Fedora doesn't support gksudo anymore.
I added an alternative command called pkexec, to make it work with Fedora.

I tested it locally and I don't know, if the additional if statement is how you want to handle different commands going forward. But it would be nice, if you could add support for Fedora by pulling this change or adopting it to your liking.

Thanks
Alex
