### PR TITLE
Add windows support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,13 @@
 # susave
 
-Package for saving a file as super user with Atom Editor.
+Package for saving a file as super user / admin with Atom Editor.
+
+**Supported Platforms**
+* GNU/Linux distributions using one of the following sudo gui commands.
+ * gksudo, kdesu, pkexec
+* Windows
+ * tested on Windows 7 only
+* Mac OS X
 
 ## Commands
 
@@ -10,3 +17,5 @@ Package for saving a file as super user with Atom Editor.
 ## Requirements
 
 * For GNU/Linux system: Install `gksudo` if you don't have.
+* On Linux you must select the right 'Sudo Gui' in the package settings for your distribution.
+ * i.e. on Fedora you must select pkexec


### PR DESCRIPTION
Hi,

I added support to "save as admin" on Windows.
Also updated the README with a section of the supported platforms.
I wasn't sure, if Mac OS X is working. Wasn't sure based on the "# I don't know if this works." comment.
If you want, I can add a untested remark below the Mac OS X bullet point.

Kind regards,
Alex
